### PR TITLE
[Environment] little Runner refactorings

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -35,22 +35,10 @@ pub fn main() {
             });
 
             ctx.then("it is not empty any more", |env| {
-                // println!("\n👉  it is not empty any more");
-                // use std::time::Duration;
-                // use std::thread;
-                // thread::sleep(Duration::from_millis(4000));
-                // println!("it is not empty any more  👈");
-
                 assert!(!env.set.is_empty());
             });
 
             ctx.then("its len increases by 1", move |env| {
-                // println!("\n👉  its len increases by 1");
-                // use std::time::Duration;
-                // use std::thread;
-                // thread::sleep(Duration::from_millis(4000));
-                // println!("its len increases by 1  👈");
-
                 assert_eq!(env.set.len(), env.len_before + 1);
             });
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -38,14 +38,8 @@ impl Runner {
 }
 
 impl Runner {
-    pub fn run<T>(self, suite: (Suite<T>, T)) -> SuiteReport
-    where
-        T: Clone + Send + Sync + ::std::fmt::Debug,
-    {
-        self.run_with(suite)
-    }
 
-    pub fn run_with<T>(self, suite: (Suite<T>, T)) -> SuiteReport
+    pub fn run<T>(self, suite: (Suite<T>, T)) -> SuiteReport
     where
         T: Clone + Send + Sync + ::std::fmt::Debug,
     {
@@ -60,14 +54,7 @@ impl Runner {
     where
         T: Clone + Send + Sync + ::std::fmt::Debug,
     {
-        self.run_or_exit_with(suite)
-    }
-
-    pub fn run_or_exit_with<T>(self, suite: (Suite<T>, T))
-    where
-        T: Clone + Send + Sync + ::std::fmt::Debug,
-    {
-        if self.run_with(suite).failed > 0 {
+        if self.run(suite).failed > 0 {
             // XXX Cargo test failure returns 101.
             //
             // > "We use 101 as the standard failure exit code because it's something unique


### PR DESCRIPTION
- Extract rayon initialization
- Rename inner collections of functions
- Remove useless `_with` variants in the Runner
