### PR TITLE
[WIP] Add support for basic test suite timing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ colored = "1.4.0"
 derive-new = "0.5.0"
 derive_builder = "0.5.0"
 rayon = "0.8.2"
+time = "0.1.38"
 
 [dependencies.expectest]
 optional = true

--- a/src/block/context.rs
+++ b/src/block/context.rs
@@ -10,7 +10,7 @@
 
 use block::{Block, Example};
 use header::{ContextLabel, ContextHeader, ExampleLabel, ExampleHeader};
-use report::ExampleReport;
+use report::ExampleResult;
 use std::default::Default;
 
 /// Test contexts are a convenient tool for adding structure and code sharing to a test suite.
@@ -252,7 +252,7 @@ where
     pub fn example<F, U>(&mut self, name: &'static str, body: F)
     where
         F: 'static + Fn(&T) -> U,
-        U: Into<ExampleReport>,
+        U: Into<ExampleResult>,
     {
         let header = ExampleHeader::new(ExampleLabel::Example, name);
         self.example_internal(header, body)
@@ -266,7 +266,7 @@ where
     pub fn it<F, U>(&mut self, name: &'static str, body: F)
     where
         F: 'static + Fn(&T) -> U,
-        U: Into<ExampleReport>,
+        U: Into<ExampleResult>,
     {
         let header = ExampleHeader::new(ExampleLabel::It, name);
         self.example_internal(header, body)
@@ -280,7 +280,7 @@ where
     pub fn then<F, U>(&mut self, name: &'static str, body: F)
     where
         F: 'static + Fn(&T) -> U,
-        U: Into<ExampleReport>,
+        U: Into<ExampleResult>,
     {
         let header = ExampleHeader::new(ExampleLabel::Then, name);
         self.example_internal(header, body)
@@ -289,7 +289,7 @@ where
     fn example_internal<F, U>(&mut self, header: ExampleHeader, body: F)
     where
         F: 'static + Fn(&T) -> U,
-        U: Into<ExampleReport>,
+        U: Into<ExampleResult>,
     {
         use std::panic::{catch_unwind, AssertUnwindSafe};
 
@@ -305,7 +305,7 @@ where
                     let message = error_as_str.or(error_as_string).map(|cow| {
                         format!("thread panicked at '{:?}'.", cow.to_string())
                     });
-                    ExampleReport::Failure(message)
+                    ExampleResult::Failure(message)
                 }
             }
         });

--- a/src/block/example.rs
+++ b/src/block/example.rs
@@ -1,16 +1,16 @@
-use report::ExampleReport;
+use report::ExampleResult;
 use header::ExampleHeader;
 
 /// Test examples are the smallest unit of a testing framework, wrapping one or more assertions.
 pub struct Example<T> {
     pub(crate) header: ExampleHeader,
-    pub(crate) function: Box<Fn(&T) -> ExampleReport>,
+    pub(crate) function: Box<Fn(&T) -> ExampleResult>,
 }
 
 impl<T> Example<T> {
     pub(crate) fn new<F>(header: ExampleHeader, assertion: F) -> Self
     where
-        F: 'static + Fn(&T) -> ExampleReport,
+        F: 'static + Fn(&T) -> ExampleResult,
     {
         Example {
             header: header,
@@ -21,19 +21,19 @@ impl<T> Example<T> {
     /// Used for testing purpose
     #[cfg(test)]
     pub fn fixture_success() -> Self {
-        Example::new(ExampleHeader::default(), |_| ExampleReport::Success)
+        Example::new(ExampleHeader::default(), |_| ExampleResult::Success)
     }
 
     /// Used for testing purpose
     #[cfg(test)]
     pub fn fixture_ignored() -> Self {
-        Example::new(ExampleHeader::default(), |_| ExampleReport::Ignored)
+        Example::new(ExampleHeader::default(), |_| ExampleResult::Ignored)
     }
 
     /// Used for testing purpose
     #[cfg(test)]
     pub fn fixture_failed() -> Self {
-        Example::new(ExampleHeader::default(), |_| ExampleReport::Failure(None))
+        Example::new(ExampleHeader::default(), |_| ExampleResult::Failure(None))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ extern crate derive_new;
 
 #[cfg(feature = "expectest_compat")]
 extern crate expectest;
-
 extern crate colored;
 extern crate rayon;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ extern crate derive_new;
 
 #[cfg(feature = "expectest_compat")]
 extern crate expectest;
+extern crate time;
 extern crate colored;
 extern crate rayon;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ mod tests {
     // x pluggable loggers via logger trait
     // - stats time events is an event handler
     // - detect slow tests via treshold
-    // - time the total running time
+    // x time the total running time
     // - failure-only via a tmp file
     // - filter tests
     // - coloration
@@ -93,8 +93,8 @@ mod tests {
     // - fail-fast fail at the first failed test
     // x beforeAll
     // x afterAll
-    // - beforeEach ?
-    // - afterEach ?
+    // x beforeEach
+    // x afterEach
     // - use Any to return anything that can be Ok-ed or () or None or panic-ed
     // - bench ? --> see what's the protocol
     //

--- a/src/logger/serial.rs
+++ b/src/logger/serial.rs
@@ -255,264 +255,31 @@ where
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     pub use super::*;
-//     pub use runner::observer::{Event, RunnerObserver};
-//     pub use example_report::*;
-//     pub use std::io;
-//     pub use std::str;
-//
-//     #[test]
-//     fn it_can_be_instanciated() {
-//         SerialLogger::new(&mut vec![1u8]);
-//     }
-//
-//     #[test]
-//     fn it_impl_logger_trait() {
-//         let _: &SerialLogger = &SerialLogger::new(&mut vec![1u8]) as &SerialLogger;
-//     }
-//
-//     mod event_start_runner {
-//         pub use super::*;
-//
-//         #[test]
-//         fn it_display_that_examples_started() {
-//             let mut v = vec![];
-//             {
-//                 let mut s = SerialLogger::new(&mut v);
-//                 s.handle(&Event::EnterSuite);
-//             }
-//
-//             assert_eq!("\ntests", str::from_utf8(&v).unwrap());
-//         }
-//     }
-//
-//     mod event_finished_runner {
-//         pub use super::*;
-//         use runner::ContextReport;
-//
-//         macro_rules! test_and_compare_output {
-//             ($(
-//                 $test_name:ident : (passed: $succ:expr, failed: $fail:expr) => $msg:expr
-//             ),+) => {
-//
-//                 $(
-//                     #[test]
-//                     fn $test_name() {
-//                         let mut sink = io::sink();
-//                         let res = {
-//                             let mut s = SerialLogger::new(&mut sink);
-//                             s.write_summary(ContextReport {
-//                                 passed: $succ,
-//                                 failed: $fail,
-//                                 ignored: 0,
-//                                 measured: 0,
-//                             })
-//                         };
-//
-//                         assert_eq!($msg, res)
-//                     }
-//                 )+
-//             }
-//         }
-//
-//         test_and_compare_output! {
-//             no_example_is_ok: (passed: 0, failed: 0) =>
-//                 "\n\ntest result: ok. 0 examples; 0 passed; 0 failed;",
-//             one_example: (passed: 1, failed: 0) =>
-//                 "\n\ntest result: ok. 1 examples; 1 passed; 0 failed;",
-//             multiple_ok: (passed: 42, failed: 0) =>
-//                 "\n\ntest result: ok. 42 examples; 42 passed; 0 failed;",
-//             one_error: (passed: 0, failed: 1) =>
-//               "\n\ntest result: FAILED. 1 examples; 0 passed; 1 failed;",
-//             multiple_errors: (passed: 0, failed: 37) =>
-//               "\n\ntest result: FAILED. 37 examples; 0 passed; 37 failed;",
-//             one_of_each: (passed: 1, failed: 1) =>
-//               "\n\ntest result: FAILED. 2 examples; 1 passed; 1 failed;",
-//             multiple_of_each: (passed: 12, failed: 21) =>
-//               "\n\ntest result: FAILED. 33 examples; 12 passed; 21 failed;"
-//         }
-//     }
-//
-//     mod event_end_example {
-//         pub use super::*;
-//
-//         #[test]
-//         fn it_displays_a_dot_when_success() {
-//             let mut v = vec![];
-//             {
-//                 let mut s = SerialLogger::new(&mut v);
-//                 s.handle(&Event::ExitExample(SUCCESS_RES))
-//             }
-//
-//             assert_eq!(".", str::from_utf8(&v).unwrap());
-//         }
-//
-//         #[test]
-//         #[allow(non_snake_case)]
-//         fn it_displays_a_F_when_error() {
-//             let mut v = vec![];
-//             {
-//                 let mut s = SerialLogger::new(&mut v);
-//                 s.handle(&Event::ExitExample(FAILED_RES))
-//             }
-//
-//             assert_eq!("F", str::from_utf8(&v).unwrap());
-//         }
-//     }
-//
-//     mod event_start_end_describe {
-//         pub use super::*;
-//
-//         #[test]
-//         fn start_describe_event_push_the_name_stack() {
-//             let mut sink = &mut io::sink();
-//             let mut s = SerialLogger::new(&mut sink);
-//
-//             s.handle(&Event::EnterContext(String::from("Hey !")));
-//             assert_eq!(vec![String::from("Hey !")], s.name_stack);
-//
-//             s.handle(&Event::EnterContext(String::from("Ho !")));
-//             assert_eq!(vec![String::from("Hey !"), String::from("Ho !")],
-//                        s.name_stack)
-//         }
-//
-//         #[test]
-//         fn end_describe_event_pop_the_name_stack() {
-//             let mut sink = &mut io::sink();
-//             let mut s = SerialLogger::new(&mut sink);
-//
-//             s.handle(&Event::EnterContext(String::from("Hey !")));
-//             s.handle(&Event::EnterContext(String::from("Ho !")));
-//
-//             s.handle(&Event::ExitContext);
-//             assert_eq!(vec![String::from("Hey !")], s.name_stack);
-//
-//             s.handle(&Event::ExitContext);
-//             assert_eq!(0, s.name_stack.len());
-//         }
-//     }
-//
-//     mod failures_pretty_printing {
-//         use super::*;
-//
-//         #[test]
-//         fn it_register_failures() {
-//             let mut sink = &mut io::sink();
-//             let mut s = SerialLogger::new(&mut sink);
-//             s.handle(&Event::EnterExample("hola".into()));
-//             s.handle(&Event::ExitExample(FAILED_RES));
-//             assert_eq!(1, s.failed.len());
-//         }
-//
-//         #[test]
-//         fn it_keep_track_of_the_failure_name() {
-//             let mut sink = &mut io::sink();
-//             let mut s = SerialLogger::new(&mut sink);
-//             s.handle(&Event::EnterExample("hola".into()));
-//             s.handle(&Event::ExitExample(FAILED_RES));
-//             assert_eq!(Some(&"hola".into()), s.failed.get(0));
-//         }
-//
-//         #[test]
-//         fn it_has_a_nice_diplay_for_describes() {
-//             let mut sink = &mut io::sink();
-//             let mut s = SerialLogger::new(&mut sink);
-//             s.handle(&Event::EnterContext("hola".into()));
-//             s.handle(&Event::EnterExample("holé".into()));
-//             s.handle(&Event::ExitExample(FAILED_RES));
-//             assert_eq!(Some(&"hola | holé".into()), s.failed.get(0));
-//
-//             s.handle(&Event::EnterContext("ohééé".into()));
-//             s.handle(&Event::EnterExample("holé".into()));
-//             s.handle(&Event::ExitExample(FAILED_RES));
-//             assert_eq!(Some(&"hola | ohééé | holé".into()), s.failed.get(1));
-//         }
-//
-//         #[test]
-//         fn it_works_with_multiple_describes() {
-//             let mut sink = &mut io::sink();
-//             let mut s = SerialLogger::new(&mut sink);
-//             s.handle(&Event::EnterContext("hola".into()));
-//             s.handle(&Event::EnterExample("holé".into()));
-//             s.handle(&Event::ExitExample(FAILED_RES));
-//
-//             s.handle(&Event::ExitContext);
-//             s.handle(&Event::EnterContext("ok".into()));
-//             s.handle(&Event::EnterExample("cacao".into()));
-//             s.handle(&Event::ExitExample(FAILED_RES));
-//             assert_eq!(Some(&"ok | cacao".into()), s.failed.get(1));
-//         }
-//
-//         #[test]
-//         fn it_doesnt_includes_success() {
-//             let mut sink = &mut io::sink();
-//             let mut s = SerialLogger::new(&mut sink);
-//             s.handle(&Event::EnterContext("hola".into()));
-//             s.handle(&Event::EnterExample("holé".into()));
-//             s.handle(&Event::ExitExample(SUCCESS_RES));
-//
-//             assert_eq!(None, s.failed.get(0));
-//         }
-//
-//         #[test]
-//         fn is_doesnt_keep_examples_in_name_stack() {
-//             let mut sink = &mut io::sink();
-//             let mut s = SerialLogger::new(&mut sink);
-//             s.handle(&Event::EnterContext("hola".into()));
-//             s.handle(&Event::EnterExample("holé".into()));
-//             s.handle(&Event::ExitExample(SUCCESS_RES));
-//             s.handle(&Event::EnterExample("holé".into()));
-//             s.handle(&Event::ExitExample(FAILED_RES));
-//
-//             // not "hola | holé | holé"
-//             assert_eq!(Some(&"hola | holé".into()), s.failed.get(0));
-//         }
-//
-//         #[test]
-//         fn format_all_failures_one_error() {
-//             let mut sink = &mut io::sink();
-//             let res = {
-//                 let mut s = SerialLogger::new(&mut sink);
-//                 s.handle(&Event::EnterContext("hola".into()));
-//                 s.handle(&Event::EnterExample("holé".into()));
-//                 s.handle(&Event::ExitExample(FAILED_RES));
-//                 s.failures_summary()
-//             };
-//
-//             assert_eq!("  1) hola | holé\n", res);
-//         }
-//
-//         #[test]
-//         fn format_all_failures() {
-//             let mut sink = &mut io::sink();
-//             let res = {
-//                 let mut s = SerialLogger::new(&mut sink);
-//                 s.handle(&Event::EnterContext("hola".into()));
-//                 s.handle(&Event::EnterExample("holé".into()));
-//                 s.handle(&Event::ExitExample(FAILED_RES));
-//                 s.handle(&Event::EnterExample("hola".into()));
-//                 s.handle(&Event::ExitExample(FAILED_RES));
-//                 s.failures_summary()
-//             };
-//
-//             assert_eq!("  1) hola | holé\n  2) hola | hola\n", res);
-//
-//             let res = {
-//                 let mut s = SerialLogger::new(&mut sink);
-//                 s.handle(&Event::EnterContext("hola".into()));
-//                 s.handle(&Event::EnterExample("holé".into()));
-//                 s.handle(&Event::ExitExample(FAILED_RES));
-//                 s.handle(&Event::ExitContext);
-//                 s.handle(&Event::EnterContext("second".into()));
-//                 s.handle(&Event::EnterContext("third".into()));
-//                 s.handle(&Event::EnterExample("hola".into()));
-//                 s.handle(&Event::ExitExample(FAILED_RES));
-//                 s.failures_summary()
-//             };
-//
-//             assert_eq!("  1) hola | holé\n  2) second | third | hola\n", res);
-//         }
-//     }
-// }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod padding {
+        use super::*;
+
+        #[test]
+        fn it_padds() {
+            // arrange
+            let expected = vec![
+                ("", 0),
+                ("  ", 1),
+                ("     ", 2),
+                ("       ", 3)
+            ];
+            for (expected_res, given_depth) in expected {
+                // act
+                let res = SerialLogger::<Vec<u8>>::padding(given_depth);
+                // assert
+                assert_eq!(String::from(expected_res), res)
+            }
+        }
+    }
+
+
+}
+

--- a/src/logger/serial.rs
+++ b/src/logger/serial.rs
@@ -155,15 +155,28 @@ impl<T: io::Write> SerialLogger<T> {
     }
 
     fn write_duration(&self, buffer: &mut T, duration: Duration) -> io::Result<()> {
-        let seconds = duration.num_seconds();
-        let hours = seconds / (60 * 60);
-        let remainder = seconds % (60 * 60);
-        let minutes = remainder / 60;
-        let seconds = remainder % 60;
-        match (hours, minutes, seconds) {
-            (0, 0, s) => writeln!(buffer, "\nduration: {}s.", s),
-            (0, m, s) => writeln!(buffer, "\nduration: {}m {}s.", m, s),
-            (h, m, s) => writeln!(buffer, "\nduration: {}h {}m {}s.", h, m, s),
+        let millisecond = 1;
+    	let second = 1000 * millisecond;
+    	let minute = 60 * second;
+    	let hour   = 60 * minute;
+
+    	let remainder = duration.num_milliseconds();
+
+    	let hours = remainder / hour;
+    	let remainder = remainder % hour;
+
+    	let minutes = remainder / minute;
+    	let remainder = remainder % minute;
+
+    	let seconds = remainder / second;
+    	let remainder = remainder % second;
+
+    	let milliseconds = remainder / millisecond;
+        match (hours, minutes, seconds, milliseconds) {
+            (0, 0, 0, ms) => writeln!(buffer, "\nduration: {}ms.", ms),
+            (0, 0, s, ms) => writeln!(buffer, "\nduration: {}s {}ms.", s, ms),
+            (0, m, s, ms) => writeln!(buffer, "\nduration: {}m {}s {}ms.", m, s, ms),
+            (h, m, s, ms) => writeln!(buffer, "\nduration: {}h {}m {}s {}ms.", h, m, s, ms),
         }
     }
 
@@ -279,7 +292,4 @@ mod tests {
             }
         }
     }
-
-
 }
-

--- a/src/logger/serial.rs
+++ b/src/logger/serial.rs
@@ -173,10 +173,9 @@ impl<T: io::Write> SerialLogger<T> {
 
     	let milliseconds = remainder / millisecond;
         match (hours, minutes, seconds, milliseconds) {
-            (0, 0, 0, ms) => writeln!(buffer, "\nduration: {}ms.", ms),
-            (0, 0, s, ms) => writeln!(buffer, "\nduration: {}s {}ms.", s, ms),
-            (0, m, s, ms) => writeln!(buffer, "\nduration: {}m {}s {}ms.", m, s, ms),
-            (h, m, s, ms) => writeln!(buffer, "\nduration: {}h {}m {}s {}ms.", h, m, s, ms),
+            (0, 0, s, ms) => writeln!(buffer, "\nduration: {}.{:03}s.", s, ms),
+            (0, m, s, ms) => writeln!(buffer, "\nduration: {}m {}.{:03}s.", m, s, ms),
+            (h, m, s, ms) => writeln!(buffer, "\nduration: {}h {}m {}.{:03}s.", h, m, s, ms),
         }
     }
 

--- a/src/logger/serial.rs
+++ b/src/logger/serial.rs
@@ -5,7 +5,7 @@ use std::ops::DerefMut;
 use colored::*;
 
 use header::{SuiteHeader, ContextHeader, ExampleHeader};
-use report::{Report, BlockReport, SuiteReport, ContextReport, ExampleReport};
+use report::{Report, BlockReport, SuiteReport, ContextReport, ExampleReport, ExampleResult};
 use runner::{Runner, RunnerObserver};
 
 #[derive(new)]
@@ -119,7 +119,7 @@ impl<T: io::Write> SerialLogger<T> {
         indent: usize,
         report: &ExampleReport,
     ) -> io::Result<()> {
-        if let &ExampleReport::Failure(Some(ref reason)) = report {
+        if let &ExampleResult::Failure(Some(ref reason)) = report.get_result() {
             let padding = Self::padding(indent);
             writeln!(buffer, "{}{}", padding, reason)?;
         }
@@ -133,8 +133,8 @@ impl<T: io::Write> SerialLogger<T> {
     }
 
     fn write_suite_suffix(&self, buffer: &mut T, report: &SuiteReport) -> io::Result<()> {
-        let flag = self.report_flag(report);
-        write!(buffer, "\ntest result: {}.", flag)?;
+        write!(buffer, "\ntest result: {}.", self.report_flag(report))?;
+
         writeln!(
             buffer,
             " {} passed; {} failed; {} ignored",

--- a/src/logger/serial.rs
+++ b/src/logger/serial.rs
@@ -281,8 +281,8 @@ mod tests {
             let expected = vec![
                 ("", 0),
                 ("  ", 1),
-                ("     ", 2),
-                ("       ", 3)
+                ("    ", 2),
+                ("      ", 3)
             ];
             for (expected_res, given_depth) in expected {
                 // act

--- a/src/report/context.rs
+++ b/src/report/context.rs
@@ -1,7 +1,7 @@
 use report::{Report, BlockReport};
 
 /// `ContextReport` holds the results of a context's test execution.
-#[derive(PartialEq, Eq, Clone, Default, Debug, new)]
+#[derive(PartialEq, Eq, Clone, Debug, new)]
 pub struct ContextReport {
     sub_reports: Vec<BlockReport>,
 }

--- a/src/report/context.rs
+++ b/src/report/context.rs
@@ -1,9 +1,11 @@
+use time::Duration;
 use report::{Report, BlockReport};
 
 /// `ContextReport` holds the results of a context's test execution.
 #[derive(PartialEq, Eq, Clone, Debug, new)]
 pub struct ContextReport {
     sub_reports: Vec<BlockReport>,
+    duration: Duration,
 }
 
 impl ContextReport {
@@ -41,6 +43,10 @@ impl Report for ContextReport {
         self.sub_reports.iter().fold(0, |count, report| {
             count + report.get_ignored()
         })
+    }
+
+    fn get_duration(&self) -> Duration {
+        self.duration
     }
 }
 

--- a/src/report/example.rs
+++ b/src/report/example.rs
@@ -1,5 +1,7 @@
 use std::convert::From;
 
+use time::Duration;
+
 use report::Report;
 
 #[cfg(feature = "expectest_compat")]
@@ -105,6 +107,7 @@ impl From<ExpectestResult> for ExampleResult {
 #[derive(Clone, PartialEq, Eq, Debug, new)]
 pub struct ExampleReport {
     result: ExampleResult,
+    duration: Duration,
 }
 
 impl ExampleReport {
@@ -132,6 +135,10 @@ impl Report for ExampleReport {
 
     fn get_ignored(&self) -> u32 {
         self.result.get_ignored()
+    }
+
+    fn get_duration(&self) -> Duration {
+        self.duration
     }
 }
 

--- a/src/report/example.rs
+++ b/src/report/example.rs
@@ -5,25 +5,32 @@ use report::Report;
 #[cfg(feature = "expectest_compat")]
 use expectest::core::TestResult as ExpectestResult;
 
-/// `ExampleReport` holds the results of a context example's test execution.
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub enum ExampleReport {
+pub enum ExampleResult {
     Success,
     Failure(Option<String>),
     Ignored,
 }
 
-impl Report for ExampleReport {
+impl ExampleResult {
     fn is_success(&self) -> bool {
-        self == &ExampleReport::Success
+        if &ExampleResult::Success == self {
+            true
+        } else {
+            false
+        }
     }
 
     fn is_failure(&self) -> bool {
-        self != &ExampleReport::Success
+        if let &ExampleResult::Failure(_) = self {
+            true
+        } else {
+            false
+        }
     }
 
     fn get_passed(&self) -> u32 {
-        if &ExampleReport::Success == self {
+        if &ExampleResult::Success == self {
             1
         } else {
             0
@@ -31,7 +38,7 @@ impl Report for ExampleReport {
     }
 
     fn get_failed(&self) -> u32 {
-        if let &ExampleReport::Failure(_) = self {
+        if let &ExampleResult::Failure(_) = self {
             1
         } else {
             0
@@ -39,7 +46,7 @@ impl Report for ExampleReport {
     }
 
     fn get_ignored(&self) -> u32 {
-        if &ExampleReport::Ignored == self {
+        if &ExampleResult::Ignored == self {
             1
         } else {
             0
@@ -48,19 +55,19 @@ impl Report for ExampleReport {
 }
 
 /// rspec considers examples returning `()` a success.
-impl From<()> for ExampleReport {
-    fn from(_other: ()) -> ExampleReport {
-        ExampleReport::Success
+impl From<()> for ExampleResult {
+    fn from(_other: ()) -> ExampleResult {
+        ExampleResult::Success
     }
 }
 
 /// rspec considers examples returning `true` a success, `false` a failure.
-impl From<bool> for ExampleReport {
-    fn from(other: bool) -> ExampleReport {
+impl From<bool> for ExampleResult {
+    fn from(other: bool) -> ExampleResult {
         if other {
-            ExampleReport::Success
+            ExampleResult::Success
         } else {
-            ExampleReport::Failure(Some(
+            ExampleResult::Failure(Some(
                 "assertion failed: `expected condition to be true`"
                     .to_owned(),
             ))
@@ -69,28 +76,62 @@ impl From<bool> for ExampleReport {
 }
 
 /// rspec considers examples returning `Result::Ok(…)` a success, `Result::Err(…)` a failure.
-impl<T1, T2> From<Result<T1, T2>> for ExampleReport
+impl<T1, T2> From<Result<T1, T2>> for ExampleResult
 where
     T2: ::std::fmt::Debug,
 {
-    fn from(other: Result<T1, T2>) -> ExampleReport {
+    fn from(other: Result<T1, T2>) -> ExampleResult {
         match other {
-            Ok(_) => ExampleReport::Success,
-            Err(error) => ExampleReport::Failure(Some(format!("{:?}", error))),
+            Ok(_) => ExampleResult::Success,
+            Err(error) => ExampleResult::Failure(Some(format!("{:?}", error))),
         }
     }
 }
 
 /// rspec considers examples returning `ExpectestResult::Ok(…)` a success, `ExpectestResult::Err(…)` a failure.
 #[cfg(feature = "expectest_compat")]
-impl From<ExpectestResult> for ExampleReport {
-    fn from(other: ExpectestResult) -> ExampleReport {
+impl From<ExpectestResult> for ExampleResult {
+    fn from(other: ExpectestResult) -> ExampleResult {
         match other {
-            ExpectestResult::Success => ExampleReport::Success,
+            ExpectestResult::Success => ExampleResult::Success,
             ExpectestResult::Failure(failure) => {
-                ExampleReport::Failure(Some(format!("{:?}", failure)))
+                ExampleResult::Failure(Some(format!("{:?}", failure)))
             }
         }
+    }
+}
+
+/// `ExampleReport` holds the results of a context example's test execution.
+#[derive(Clone, PartialEq, Eq, Debug, new)]
+pub struct ExampleReport {
+    result: ExampleResult,
+}
+
+impl ExampleReport {
+    pub fn get_result(&self) -> &ExampleResult {
+        &self.result
+    }
+}
+
+impl Report for ExampleReport {
+    fn is_success(&self) -> bool {
+        self.result.is_success()
+    }
+
+    fn is_failure(&self) -> bool {
+        self.result.is_failure()
+    }
+
+    fn get_passed(&self) -> u32 {
+        self.result.get_passed()
+    }
+
+    fn get_failed(&self) -> u32 {
+        self.result.get_failed()
+    }
+
+    fn get_ignored(&self) -> u32 {
+        self.result.get_ignored()
     }
 }
 
@@ -100,21 +141,21 @@ mod tests {
 
     #[test]
     fn from_void() {
-        assert!(ExampleReport::from(()).is_success());
+        assert!(ExampleResult::from(()).is_success());
     }
 
     #[test]
     fn from_bool() {
-        assert!(ExampleReport::from(true).is_success());
-        assert!(ExampleReport::from(false).is_failure());
+        assert!(ExampleResult::from(true).is_success());
+        assert!(ExampleResult::from(false).is_failure());
     }
 
     #[test]
     fn from_result() {
         let ok_result: Result<(), ()> = Ok(());
         let err_result: Result<(), ()> = Err(());
-        assert!(ExampleReport::from(ok_result).is_success());
-        assert!(ExampleReport::from(err_result).is_failure());
+        assert!(ExampleResult::from(ok_result).is_success());
+        assert!(ExampleResult::from(err_result).is_failure());
     }
 
     #[cfg(feature = "expectest_compat")]
@@ -124,7 +165,7 @@ mod tests {
         let ok_result = ExpectestResult::new_success();
         // A failure ExpectestResult panics on drop, hence the `#[should_panic]`.
         let err_result = ExpectestResult::new_failure("dummy".to_owned(), None);
-        assert!(ExampleReport::from(ok_result).is_success());
-        assert!(ExampleReport::from(err_result).is_failure());
+        assert!(ExampleResult::from(ok_result).is_success());
+        assert!(ExampleResult::from(err_result).is_failure());
     }
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -4,6 +4,8 @@ mod suite;
 mod context;
 mod example;
 
+pub use time::Duration;
+
 pub use report::suite::*;
 pub use report::context::*;
 pub use report::example::*;
@@ -19,6 +21,8 @@ pub trait Report {
     fn get_passed(&self) -> u32;
     fn get_failed(&self) -> u32;
     fn get_ignored(&self) -> u32;
+
+    fn get_duration(&self) -> Duration;
 }
 
 /// `BlockReport` holds the results of a context block's test execution.
@@ -70,6 +74,13 @@ impl Report for BlockReport {
         match self {
             &BlockReport::Context(_, ref report) => report.get_ignored(),
             &BlockReport::Example(_, ref report) => report.get_ignored(),
+        }
+    }
+
+    fn get_duration(&self) -> Duration {
+        match self {
+            &BlockReport::Context(_, ref report) => report.get_duration(),
+            &BlockReport::Example(_, ref report) => report.get_duration(),
         }
     }
 }

--- a/src/report/suite.rs
+++ b/src/report/suite.rs
@@ -1,3 +1,5 @@
+use time::Duration;
+
 use header::SuiteHeader;
 use report::{Report, ContextReport};
 
@@ -37,6 +39,10 @@ impl Report for SuiteReport {
 
     fn get_ignored(&self) -> u32 {
         self.context.get_ignored()
+    }
+
+    fn get_duration(&self) -> Duration {
+        self.context.get_duration()
     }
 }
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -14,6 +14,8 @@ use std::panic;
 use std::process;
 use std::sync::{Arc, Mutex};
 
+use time::PreciseTime;
+
 use rayon::prelude::*;
 
 use block::Block;
@@ -228,6 +230,7 @@ where
         if let Some(ref header) = context.header {
             self.broadcast(|handler| handler.enter_context(self, &header));
         }
+        let start_time = PreciseTime::now();
         let reports: Vec<_> =
             self.wrap_all(context, environment, |environment| if self.configuration
                 .parallel
@@ -236,7 +239,8 @@ where
             } else {
                 self.evaluate_blocks_serial(context, environment)
             });
-        let report = ContextReport::new(reports);
+        let end_time = PreciseTime::now();
+        let report = ContextReport::new(reports, start_time.to(end_time));
         if let Some(ref header) = context.header {
             self.broadcast(|handler| handler.exit_context(self, &header, &report));
         }
@@ -253,8 +257,10 @@ where
 
     fn visit(&self, example: &Example<T>, environment: &mut Self::Environment) -> Self::Output {
         self.broadcast(|handler| handler.enter_example(self, &example.header));
+        let start_time = PreciseTime::now();
         let result = (example.function)(environment);
-        let report = ExampleReport::new(result);
+        let end_time = PreciseTime::now();
+        let report = ExampleReport::new(result, start_time.to(end_time));
         self.broadcast(|handler| handler.exit_example(self, &example.header, &report));
         report
     }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -253,8 +253,8 @@ where
 
     fn visit(&self, example: &Example<T>, environment: &mut Self::Environment) -> Self::Output {
         self.broadcast(|handler| handler.enter_example(self, &example.header));
-        let function = &example.function;
-        let report = function(environment);
+        let result = (example.function)(environment);
+        let report = ExampleReport::new(result);
         self.broadcast(|handler| handler.exit_example(self, &example.header, &report));
         report
     }
@@ -648,7 +648,7 @@ mod tests {
             // act
             let example = Example::new(ExampleHeader::default(), |env : &Arc<AtomicBool>| {
                 env.store(true, Ordering::SeqCst);
-                ExampleReport::Success
+                ExampleResult::Success
             });
             runner.visit(&example, &mut environment);
             // assert


### PR DESCRIPTION
Two open issues with this:

1. Given rspec's nature of sharing context/computation among tests durations for individual `Example<T>` or `Context<T>` might not be too useful. As such for now I'm only logging the entire suite's duration.
2. Not sure how to test this properly without mocking the time-source, which would complicate the implementation/type signature of `Runner`.