### PR TITLE
Update cargo dependencies for Fedora packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ version = "0.0.153"
 [dependencies]
 colored = "1.4.0"
 derive-new = "0.5.0"
-derive_builder = "0.5.0"
-rayon = "0.8.2"
+derive_builder = "0.9.0"
+rayon = "1.3.1"
 time = "0.1.38"
 
 [dependencies.expectest]

--- a/src/block/context.rs
+++ b/src/block/context.rs
@@ -16,10 +16,10 @@ use report::ExampleResult;
 pub struct Context<T> {
     pub(crate) header: Option<ContextHeader>,
     pub(crate) blocks: Vec<Block<T>>,
-    pub(crate) before_all: Vec<Box<Fn(&mut T)>>,
-    pub(crate) before_each: Vec<Box<Fn(&mut T)>>,
-    pub(crate) after_all: Vec<Box<Fn(&mut T)>>,
-    pub(crate) after_each: Vec<Box<Fn(&mut T)>>,
+    pub(crate) before_all: Vec<Box<dyn Fn(&mut T)>>,
+    pub(crate) before_each: Vec<Box<dyn Fn(&mut T)>>,
+    pub(crate) after_all: Vec<Box<dyn Fn(&mut T)>>,
+    pub(crate) after_each: Vec<Box<dyn Fn(&mut T)>>,
 }
 
 impl<T> Context<T> {

--- a/src/block/example.rs
+++ b/src/block/example.rs
@@ -4,7 +4,7 @@ use header::ExampleHeader;
 /// Test examples are the smallest unit of a testing framework, wrapping one or more assertions.
 pub struct Example<T> {
     pub(crate) header: ExampleHeader,
-    pub(crate) function: Box<Fn(&T) -> ExampleResult>,
+    pub(crate) function: Box<dyn Fn(&T) -> ExampleResult>,
 }
 
 impl<T> Example<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,6 @@ where
     use std::io;
     use std::sync::Arc;
 
-    use logger::Logger;
-    use runner::{ConfigurationBuilder, Runner};
 
     let logger = Arc::new(Logger::new(io::stdout()));
     let configuration = ConfigurationBuilder::default().build().unwrap();

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -31,12 +31,12 @@ use visitor::TestSuiteVisitor;
 /// Runner for executing a test suite's examples.
 pub struct Runner {
     pub configuration: configuration::Configuration,
-    observers: Vec<Arc<RunnerObserver>>,
+    observers: Vec<Arc<dyn RunnerObserver>>,
     should_exit: Mutex<Cell<bool>>,
 }
 
 impl Runner {
-    pub fn new(configuration: Configuration, observers: Vec<Arc<RunnerObserver>>) -> Runner {
+    pub fn new(configuration: Configuration, observers: Vec<Arc<dyn RunnerObserver>>) -> Runner {
         Runner {
             configuration: configuration,
             observers: observers,
@@ -62,7 +62,7 @@ impl Runner {
 
     fn broadcast<F>(&self, mut handler: F)
     where
-        F: FnMut(&RunnerObserver),
+        F: FnMut(&dyn RunnerObserver),
     {
         for observer in &self.observers {
             handler(observer.borrow());


### PR DESCRIPTION
We're in the process of adding this project as a `rust-package` in Fedora to resolve one of the dependencies for building the `rust-mbrman` package. This PR will bump up a few package dependencies to make it work in Fedora. 